### PR TITLE
Fix: Align password input on login and registration pages

### DIFF
--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -72,3 +72,5 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+@import './styles/forms';

--- a/src/assets/styles/_forms.scss
+++ b/src/assets/styles/_forms.scss
@@ -1,0 +1,7 @@
+.p-password {
+  width: 100%;
+
+  .p-inputtext {
+    width: 100%;
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,12 @@
 import { createApp } from 'vue';
 import App from './App.vue';
-import router from './router'; 
+import router from './router';
 import ToastService from 'primevue/toastservice';
 import PrimeVue from 'primevue/config';
 import Aura from '@primeuix/themes/aura';
+
+// Style file
+import '@/assets/styles.scss';
 
 // Icon CSS file
 import 'primeicons/primeicons.css';


### PR DESCRIPTION
This commit fixes a styling issue where the password input field on the login and registration pages was not aligned with other form inputs.

The PrimeVue `p-password` component was not inheriting the full width of its container. This was resolved by adding a global CSS override to ensure both the component and its inner input element have a width of 100%.

- Created a new `_forms.scss` file in `src/assets/styles/` to house form-related styles.
- Added a style rule to target `.p-password` and set its width to 100%.
- Imported the new stylesheet into the main `styles.scss` file.
- Moved the main stylesheet from `src/style.css` to `src/assets/styles.scss` for better organization.
- Updated `main.js` to import the new global stylesheet.